### PR TITLE
add paragraph dependency

### DIFF
--- a/config/optional/migrate_plus.migration.migrate_nodes_example.yml
+++ b/config/optional/migrate_plus.migration.migrate_nodes_example.yml
@@ -1,0 +1,50 @@
+# This is just an example.
+#id: migrate_nodes_example
+#label: Tide migration example - nodes
+#migration_group: tide_migration_entities
+#source:
+#  plugin: tide_migration_node_source
+#  key: default
+#  bundle: article
+#  field_names:
+#    - body
+#    - comment
+#    - field_components
+#    - field_help
+#    - field_image
+#    - field_options
+#    - field_tags
+#process:
+#  nid: nid
+#  type:
+#    plugin: default_value
+#    default_value: article
+#  title: title
+#  body:
+#    plugin: sub_process
+#    source: body
+#    process:
+#      value: value
+#      format:
+#        plugin: default_value
+#        default_value: 'basic_html'
+#  field_components:
+#    plugin: tide_migration_paragraph_process
+#    migrate_ids:
+#      - migrate_paragraph_example
+#      - migrate_paragraph_example_b
+#    target_field: field_components
+#    overwrite: false
+#destination:
+#  plugin: 'entity:node'
+#  default_bundle: article
+#  overwrite_properties:
+#    - field_components
+#migration_dependencies:
+#  optional:
+#    - migrate_paragraph_example
+#    - migrate_paragraph_example_b
+#dependencies:
+#  enforced:
+#    module:
+#      - tide_migration

--- a/config/optional/migrate_plus.migration.migrate_paragraph_example.yml
+++ b/config/optional/migrate_plus.migration.migrate_paragraph_example.yml
@@ -1,0 +1,36 @@
+# This is just an example.
+#id: migrate_paragraph_example
+#label: Tide migration example - paragraphs
+#migration_group: tide_migration_entities
+#source:
+#  plugin: tide_migration_paragraph_source
+#  key: default
+#  bundle: paragraph_a
+#  field_names:
+#    - field_title
+#    - field_summary
+#    - field_image
+#process:
+#  parent_id: parent_id
+#  parent_type: parent_type
+#  parent_field_name: parent_field_name
+#  field_title:
+#    plugin: sub_process
+#    source: field_title
+#    process:
+#      value: value
+#  field_summary:
+#    plugin: sub_process
+#    source: field_summary
+#    process:
+#      value: value
+#      format:
+#        plugin: default_value
+#        default_value: 'basic_html'
+#destination:
+#  plugin: 'entity_reference_revisions:paragraph'
+#  default_bundle: paragraph_b
+#dependencies:
+#  enforced:
+#    module:
+#      - tide_migration

--- a/config/optional/migrate_plus.migration.migrate_paragraph_example_b.yml
+++ b/config/optional/migrate_plus.migration.migrate_paragraph_example_b.yml
@@ -1,0 +1,36 @@
+# This is just an example.
+#id: migrate_paragraph_example_b
+#label: Tide migration example - paragraphs
+#migration_group: tide_migration_entities
+#source:
+#  plugin: tide_migration_paragraph_source
+#  key: default
+#  bundle: paragraph_a
+#  field_names:
+#    - field_title
+#    - field_summary
+#    - field_image
+#process:
+#  parent_id: parent_id
+#  parent_type: parent_type
+#  parent_field_name: parent_field_name
+#  field_title:
+#    plugin: sub_process
+#    source: field_title
+#    process:
+#      value: value
+#  field_summary:
+#    plugin: sub_process
+#    source: field_summary
+#    process:
+#      value: value
+#      format:
+#        plugin: default_value
+#        default_value: 'basic_html'
+#destination:
+#  plugin: 'entity_reference_revisions:paragraph'
+#  default_bundle: paragraph_c
+#dependencies:
+#  enforced:
+#    module:
+#      - tide_migration

--- a/config/optional/migrate_plus.migration_group.tide_migration_entities.yml
+++ b/config/optional/migrate_plus.migration_group.tide_migration_entities.yml
@@ -1,0 +1,10 @@
+# This is just an example.
+#id: tide_migration_entities
+#label: example
+#description: example
+#source_type: example
+#shared_configuration: null
+#dependencies:
+#  enforced:
+#    module:
+#      - tide_migration

--- a/src/Plugin/migrate/process/TideMigrationNodeReferenceToLinkProcess.php
+++ b/src/Plugin/migrate/process/TideMigrationNodeReferenceToLinkProcess.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\tide_migration\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\MigrateSkipProcessException;
+use Drupal\migrate\MigrateSkipRowException;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Drupal\node\Entity\Node;
+
+/**
+ * This plugin currently node reference to link.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "tide_migration_node_reference_to_link_process",
+ * )
+ *
+ * @code
+ * source:
+ *   plugin: tide_migration_node_reference_to_link_process
+ *   source: value
+ * @endcode
+ *
+ */
+class TideMigrationNodeReferenceToLinkProcess extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $id = $row->getSourceProperty('id');
+    $parent_id = $row->getSourceProperty('parent_id');
+    if (!$value) {
+      throw new MigrateSkipProcessException('paragraph id=' . $id . ', node id=' . $parent_id, TRUE);
+    }
+    if (!isset($value['target_id'])) {
+      throw new MigrateSkipProcessException('paragraph id =' . $id . ', node id=' . $parent_id, TRUE);
+    }
+    if (isset($value['target_id'])) {
+      if (Node::load($value['target_id'])) {
+        return 'entity:node/' . $value['target_id'];
+      }
+      else {
+        return 'internal:/node/' . $value['target_id'];
+      }
+    }
+    throw new MigrateSkipProcessException('paragraph id =' . $id . ', node id=' . $parent_id, TRUE);
+  }
+}

--- a/src/Plugin/migrate/process/TideMigrationParagraphProcess.php
+++ b/src/Plugin/migrate/process/TideMigrationParagraphProcess.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\tide_migration\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateException;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * This plugin currently can only be used in nodes migration for returning
+ * paragraph values.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "tide_migration_paragraph_process",
+ *   handle_multiples = TRUE
+ * )
+ *
+ * @code
+ * source:
+ *   plugin: tide_migration_paragraph_process
+ *   migrate_ids:
+ *     - migrate_paragraph_example
+ *     - migrate_paragraph_example_b
+ *   target_field: field_components
+ *   overwrite: false
+ * @endcode
+ *
+ */
+class TideMigrationParagraphProcess extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    if (empty($this->configuration['migrate_ids'])) {
+      throw new MigrateException('migrate_ids is empty');
+    }
+    if (empty($this->configuration['target_field'])) {
+      throw new MigrateException('target_field is empty');
+    }
+    $paragraphs = [];
+    foreach ($this->configuration['migrate_ids'] as $migrate_id) {
+      $results = \Drupal::database()
+        ->select('migrate_map_' . $migrate_id, $migrate_id)
+        ->fields($migrate_id, ['destid1', 'destid2'])
+        ->condition($migrate_id . '.sourceid2', $row->getSourceProperty('nid'), '=')
+        ->execute()
+        ->fetchAll();
+      if (!empty($results)) {
+        foreach ($results as $result) {
+          $paragraphs[] = [
+            'target_id' => $result->destid1,
+            'target_revision_id' => $result->destid2,
+          ];
+        }
+      }
+    }
+    if ($this->configuration['overwrite'] == TRUE){
+      return $paragraphs;
+    }
+    return array_merge($paragraphs, $row->getSourceProperty($this->configuration['target_field']));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function multiple() {
+    return TRUE;
+  }
+
+}

--- a/src/Plugin/migrate/source/TideMigrationNodeSource.php
+++ b/src/Plugin/migrate/source/TideMigrationNodeSource.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Drupal\tide_migration\Plugin\migrate\source;
+
+use Drupal\migrate\Plugin\migrate\source\SqlBase;
+use Drupal\migrate\Row;
+use Drupal\migrate\Plugin\Exception\BadPluginDefinitionException;
+use Drupal\node\Entity\Node;
+
+/**
+ * Source plugin for retrieving node values.
+ *
+ * @MigrateSource(
+ *   id = "tide_migration_node_source"
+ * )
+ *
+ * Example usage in migrate config yaml file:
+ *
+ * @code
+ * source:
+ *   plugin: tide_migration_node_source
+ *   key: default
+ *   bundle: tide_landing_page
+ *   field_names:
+ *     - field_name_1
+ *     - field_name_2
+ *     - field_name_3
+ * @endcode
+ *
+ */
+class TideMigrationNodeSource extends SqlBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    $fields = [
+      'nid' => $this->t('Node ID'),
+      'vid' => $this->t('Node revision ID'),
+      'type' => $this->t('Node bundle'),
+      'title' => $this->t('Node title'),
+      'uid' => $this->t('Node user id'),
+      'created' => $this->t('Node created time - timestamp'),
+      'changed' => $this->t('Node changed time - timestamp'),
+    ];
+    return $fields;
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() {
+    return [
+      'nid' => [
+        'type' => 'integer',
+        'alias' => 'tmns',
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    if (!isset($this->configuration['bundle'])) {
+      throw new BadPluginDefinitionException($this->pluginDefinition['source']['plugin'], 'bundle');
+    }
+    if (!isset($this->configuration['field_names'])) {
+      throw new BadPluginDefinitionException($this->pluginDefinition['source']['plugin'], 'field_names');
+    }
+    $fields = [
+      'nid',
+      'vid',
+      'type',
+      'title',
+      'uid',
+      'created',
+      'changed',
+    ];
+    $query = $this->select('node_field_data', 'tmns')
+      ->fields('tmns', $fields)
+      ->condition('type', $this->configuration['bundle']);
+    return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepareRow(Row $row) {
+    if (!isset($this->configuration['field_names'])) {
+      throw new BadPluginDefinitionException($this->pluginDefinition['source']['plugin'], 'field_names');
+    }
+    // Gets current Node entity.
+    $nid = $row->getSourceProperty('nid');
+    $node = Node::load($nid);
+    // Loop fields.
+    foreach ($this->configuration['field_names'] as $field_name) {
+      $value = $node->get($field_name)->getValue();
+      $row->setSourceProperty($field_name, $value);
+    }
+    return parent::prepareRow($row);
+  }
+
+}

--- a/src/Plugin/migrate/source/TideMigrationParagraphSource.php
+++ b/src/Plugin/migrate/source/TideMigrationParagraphSource.php
@@ -90,11 +90,12 @@ class TideMigrationParagraphSource extends SqlBase {
       'parent_field_name',
       'created',
     ];
-    $query = $this->select('paragraphs_item_field_data', 'tmps')
-      ->fields('tmps', $fields)
-      ->condition('type', $this->configuration['bundle'])
-      ->condition('parent_type', $this->configuration['parent_type'])
-      ->condition('parent_field_name', $this->configuration['parent_field_name']);
+    $query = $this->select('paragraphs_item_field_data', 'tmps');
+    $query->innerJoin('node__field_landing_page_component', 'n', 'n.field_landing_page_component_target_id=tmps.id');
+    $query->fields('tmps', $fields)
+      ->condition('tmps.type', $this->configuration['bundle'])
+      ->condition('tmps.parent_type', $this->configuration['parent_type'])
+      ->condition('tmps.parent_field_name', $this->configuration['parent_field_name']);
     return $query;
   }
 
@@ -105,6 +106,7 @@ class TideMigrationParagraphSource extends SqlBase {
     if (!isset($this->configuration['field_names'])) {
       throw new BadPluginDefinitionException($this->pluginDefinition['source']['plugin'], 'field_names');
     }
+
     // Gets current Paragraph entity.
     $paragraph_id = $row->getSourceProperty('id');
     $paragraph = Paragraph::load($paragraph_id);

--- a/src/Plugin/migrate/source/TideMigrationParagraphSource.php
+++ b/src/Plugin/migrate/source/TideMigrationParagraphSource.php
@@ -21,6 +21,9 @@ use Drupal\paragraphs\Entity\Paragraph;
  *   plugin: tide_migration_paragraph_source
  *   key: default
  *   bundle: paragraph_a
+ *   parent_type: node
+ *   parent_field_name: field_landing_page_component
+ *   bundle: paragraph_a
  *   field_names:
  *     - field_name_1
  *     - field_name_2
@@ -72,6 +75,12 @@ class TideMigrationParagraphSource extends SqlBase {
     if (!isset($this->configuration['field_names'])) {
       throw new BadPluginDefinitionException($this->pluginDefinition['source']['plugin'], 'field_names');
     }
+    if (!isset($this->configuration['field_names'])) {
+      throw new BadPluginDefinitionException($this->pluginDefinition['source']['plugin'], 'parent_type');
+    }
+    if (!isset($this->configuration['field_names'])) {
+      throw new BadPluginDefinitionException($this->pluginDefinition['source']['plugin'], 'parent_field_name');
+    }
     $fields = [
       'id',
       'revision_id',
@@ -83,7 +92,9 @@ class TideMigrationParagraphSource extends SqlBase {
     ];
     $query = $this->select('paragraphs_item_field_data', 'tmps')
       ->fields('tmps', $fields)
-      ->condition('type', $this->configuration['bundle']);
+      ->condition('type', $this->configuration['bundle'])
+      ->condition('parent_type', $this->configuration['parent_type'])
+      ->condition('parent_field_name', $this->configuration['parent_field_name']);
     return $query;
   }
 

--- a/src/Plugin/migrate/source/TideMigrationParagraphSource.php
+++ b/src/Plugin/migrate/source/TideMigrationParagraphSource.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Drupal\tide_migration\Plugin\migrate\source;
+
+use Drupal\migrate\Plugin\migrate\source\SqlBase;
+use Drupal\migrate\Row;
+use Drupal\migrate\Plugin\Exception\BadPluginDefinitionException;
+use Drupal\paragraphs\Entity\Paragraph;
+
+/**
+ * Source plugin for retrieving paragraph values.
+ *
+ * @MigrateSource(
+ *   id = "tide_migration_paragraph_source"
+ * )
+ *
+ * Example usage in migrate config yaml file:
+ *
+ * @code
+ * source:
+ *   plugin: tide_migration_paragraph_source
+ *   key: default
+ *   bundle: paragraph_a
+ *   field_names:
+ *     - field_name_1
+ *     - field_name_2
+ *     - field_name_3
+ * @endcode
+ *
+ */
+class TideMigrationParagraphSource extends SqlBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    $fields = [
+      'id' => $this->t('Paragraph ID'),
+      'revision_id' => $this->t('Paragraph revision ID'),
+      'type' => $this->t('Paragraph bundle'),
+      'parent_id' => $this->t('Node title'),
+      'parent_type' => $this->t('Parent entity type'),
+      'parent_field_name' => $this->t('Parent entity field name'),
+      'created' => $this->t('Paragraph created time - timestamp'),
+    ];
+    return $fields;
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() {
+    return [
+      'id' => [
+        'type' => 'integer',
+        'alias' => 'tmps',
+      ],
+      'parent_id' => [
+        'type' => 'integer',
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    if (!isset($this->configuration['bundle'])) {
+      throw new BadPluginDefinitionException($this->pluginDefinition['source']['plugin'], 'bundle');
+    }
+    if (!isset($this->configuration['field_names'])) {
+      throw new BadPluginDefinitionException($this->pluginDefinition['source']['plugin'], 'field_names');
+    }
+    $fields = [
+      'id',
+      'revision_id',
+      'type',
+      'parent_id',
+      'parent_type' ,
+      'parent_field_name',
+      'created',
+    ];
+    $query = $this->select('paragraphs_item_field_data', 'tmps')
+      ->fields('tmps', $fields)
+      ->condition('type', $this->configuration['bundle']);
+    return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepareRow(Row $row) {
+    if (!isset($this->configuration['field_names'])) {
+      throw new BadPluginDefinitionException($this->pluginDefinition['source']['plugin'], 'field_names');
+    }
+    // Gets current Paragraph entity.
+    $paragraph_id = $row->getSourceProperty('id');
+    $paragraph = Paragraph::load($paragraph_id);
+    // Loop fields.
+    foreach ($this->configuration['field_names'] as $field_name) {
+      $value = $paragraph->get($field_name)->getValue();
+      $row->setSourceProperty($field_name, $value);
+    }
+    return parent::prepareRow($row);
+  }
+
+}


### PR DESCRIPTION
## Jira
https://digital-engagement.atlassian.net/browse/SDPA-4733
https://digital-engagement.atlassian.net/browse/SDPA-4734
___
#### supports paragraph field with multiple values.
 *it is 100% usable, but still WIP.*
- both node and paragraph migrations could do rollback operation.
- could be running under group migration. 
   - be mind the migration order. paragraph first -> node next , in other word please use `migration_dependencies`
- ...
- 
----
this PR will be useful if doing field change or field type change. devs don't need to write any update hook.
*TODO:*
1. ~`add new ones` or `overwrite` the field value.~
2. some code might need to refactor
3. write an example about how to implement migration in an update hook. 
