### PR TITLE
fix: BatchStorage fails to serialize

### DIFF
--- a/src/Form/TideMigrationForm.php
+++ b/src/Form/TideMigrationForm.php
@@ -99,7 +99,6 @@ class TideMigrationForm extends FormBase {
     ];
     $form['tide_migration']['source_file'] = [
       '#type' => 'file',
-      '#multiple' => TRUE,
       '#title' => $this->t('Data source file'),
       '#description' => t('Select the data file you want to migrate, allowed extensions: csv, json or xml.'),
     ];


### PR DESCRIPTION
### Issue
It should relate to https://www.drupal.org/project/drupal/issues/59750, which has been fixed, but it also introduced a new issue where the File form element’s `#multiple` MUST be set to false, otherwise, it will cause a fatal error in migration UI.